### PR TITLE
Update getting_started/sites with cloud info

### DIFF
--- a/content/en/getting_started/site/_index.md
+++ b/content/en/getting_started/site/_index.md
@@ -17,13 +17,13 @@ You can identify which site you are on by matching your Datadog website URL to t
 
 {{< img src="getting_started/site/site.png" alt="The site URL in your browser tab" style="width:40%" >}}
 
-| Site    | Site URL                    | Site Parameter      | Location |
-|---------|-----------------------------|---------------------|----------|
-| US1     | `https://app.datadoghq.com` | `datadoghq.com`     | US       |
-| US3     | `https://us3.datadoghq.com` | `us3.datadoghq.com` | US       |
-| US5     | `https://us5.datadoghq.com` | `us5.datadoghq.com` | US       |
-| EU1     | `https://app.datadoghq.eu`  | `datadoghq.eu`      | EU       |
-| US1-FED | `https://app.ddog-gov.com`  | `ddog-gov.com`      | US       |
+| Site    | Site URL                    | Site Parameter      | Location | Cloud       |
+|---------|-----------------------------|---------------------|----------|-------------|
+| US1     | `https://app.datadoghq.com` | `datadoghq.com`     | US       | AWS         |
+| US3     | `https://us3.datadoghq.com` | `us3.datadoghq.com` | US       | Azure       |
+| US5     | `https://us5.datadoghq.com` | `us5.datadoghq.com` | US       | GCP         |
+| EU1     | `https://app.datadoghq.eu`  | `datadoghq.eu`      | EU       | GCP         |
+| US1-FED | `https://app.ddog-gov.com`  | `ddog-gov.com`      | US       | AWS Federal |
 
 
 ## Real User Monitoring (RUM) domains


### PR DESCRIPTION
Adding the Clouds that each DD Site is located within (per private conversations and open data lookup)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
